### PR TITLE
Support for url quoted file name links produced by Obsidian.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,13 @@ markdown_extensions:
 
 </td></tr></table>
 
+#### Supporting links produced by Obsidina.md
+
+[Obsidian.md](https://obsidian.md) creates links to other markdown files by using URL quotation so instead `[Link to a file](link to a file.md)` we will see `[Link to a file](link%20to%20a%20file.md)`. If we remove URL quotation manually from a link, then Obsidian.md is not able to support this link and basic functionalities like link jumping and graph display are not working. Since mkdocs can be used as a presentation layer, then a valid place to remove URL quotations is to do it just before parsing markdown files and producing static documentation. To remove URL quotation from links, use this for **mkdocs.yaml**:
+
+```yaml
+unquote_links: true
+```
 
 
 [mkdocs-nav]: https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation

--- a/mkdocs_literate_nav/parser.py
+++ b/mkdocs_literate_nav/parser.py
@@ -33,10 +33,12 @@ class NavParser:
         get_nav_for_dir: Callable[[str], Optional[Tuple[str, str]]],
         globber,
         implicit_index: bool = False,
+        unquote_name: bool = False,
     ):
         self.get_nav_for_dir = get_nav_for_dir
         self.globber = globber
         self.implicit_index = implicit_index
+        self.unquote_name = unquote_name
         self.seen_items = set()
         self._warn = functools.lru_cache()(log.warning)
 
@@ -98,6 +100,9 @@ class NavParser:
                     error += "Did not find any item/section content specified." + _EXAMPLES
             if error:
                 raise LiterateNavParseError(error, item)
+
+            if self.unquote_name:
+                out_item = urllib.parse.unquote(out_item)
 
             if type(out_item) in (str, list, DirectoryWildcard) and out_title is not None:
                 out_item = {out_title: out_item}

--- a/mkdocs_literate_nav/parser.py
+++ b/mkdocs_literate_nav/parser.py
@@ -33,12 +33,12 @@ class NavParser:
         get_nav_for_dir: Callable[[str], Optional[Tuple[str, str]]],
         globber,
         implicit_index: bool = False,
-        unquote_name: bool = False,
+        unquote_links: bool = False,
     ):
         self.get_nav_for_dir = get_nav_for_dir
         self.globber = globber
         self.implicit_index = implicit_index
-        self.unquote_name = unquote_name
+        self.unquote_links = unquote_links
         self.seen_items = set()
         self._warn = functools.lru_cache()(log.warning)
 
@@ -101,7 +101,7 @@ class NavParser:
             if error:
                 raise LiterateNavParseError(error, item)
 
-            if self.unquote_name:
+            if self.unquote_links:
                 out_item = urllib.parse.unquote(out_item)
 
             if type(out_item) in (str, list, DirectoryWildcard) and out_title is not None:

--- a/mkdocs_literate_nav/plugin.py
+++ b/mkdocs_literate_nav/plugin.py
@@ -28,7 +28,7 @@ class LiterateNavPlugin(mkdocs.plugins.BasePlugin):
     config_scheme = (
         ("nav_file", mkdocs.config.config_options.Type(str, default="SUMMARY.md")),
         ("implicit_index", mkdocs.config.config_options.Type(bool, default=False)),
-        ("unquote_name", mkdocs.config.config_options.Type(bool, default=False)),
+        ("unquote_links", mkdocs.config.config_options.Type(bool, default=False)),
     )
 
     def on_files(self, files: mkdocs.structure.files.Files, config: mkdocs.config.Config):
@@ -37,7 +37,7 @@ class LiterateNavPlugin(mkdocs.plugins.BasePlugin):
             files,
             nav_file_name=self.config["nav_file"],
             implicit_index=self.config["implicit_index"],
-            unquote_name=self.config["unquote_name"]
+            unquote_links=self.config["unquote_links"]
         )
         self._files = files
 
@@ -58,7 +58,7 @@ def resolve_directories_in_nav(
     nav_data, files: mkdocs.structure.files.Files,
     nav_file_name: str,
     implicit_index: bool,
-    unquote_name: bool
+    unquote_links: bool
 ):
     """Walk through a standard MkDocs nav config and replace `directory/` references.
 
@@ -83,7 +83,7 @@ def resolve_directories_in_nav(
 
     globber = MkDocsGlobber(files)
     nav_parser = parser.NavParser(get_nav_for_dir, globber, implicit_index=implicit_index,
-                                  unquote_name=unquote_name)
+                                  unquote_links=unquote_links)
 
     result = None
     if not nav_data or get_nav_for_dir("."):

--- a/mkdocs_literate_nav/plugin.py
+++ b/mkdocs_literate_nav/plugin.py
@@ -28,6 +28,7 @@ class LiterateNavPlugin(mkdocs.plugins.BasePlugin):
     config_scheme = (
         ("nav_file", mkdocs.config.config_options.Type(str, default="SUMMARY.md")),
         ("implicit_index", mkdocs.config.config_options.Type(bool, default=False)),
+        ("unquote_name", mkdocs.config.config_options.Type(bool, default=False)),
     )
 
     def on_files(self, files: mkdocs.structure.files.Files, config: mkdocs.config.Config):
@@ -36,6 +37,7 @@ class LiterateNavPlugin(mkdocs.plugins.BasePlugin):
             files,
             nav_file_name=self.config["nav_file"],
             implicit_index=self.config["implicit_index"],
+            unquote_name=self.config["unquote_name"]
         )
         self._files = files
 
@@ -53,7 +55,10 @@ class LiterateNavPlugin(mkdocs.plugins.BasePlugin):
 
 
 def resolve_directories_in_nav(
-    nav_data, files: mkdocs.structure.files.Files, nav_file_name: str, implicit_index: bool
+    nav_data, files: mkdocs.structure.files.Files,
+    nav_file_name: str,
+    implicit_index: bool,
+    unquote_name: bool
 ):
     """Walk through a standard MkDocs nav config and replace `directory/` references.
 
@@ -77,7 +82,8 @@ def resolve_directories_in_nav(
             return nav_file_name, f.read()
 
     globber = MkDocsGlobber(files)
-    nav_parser = parser.NavParser(get_nav_for_dir, globber, implicit_index=implicit_index)
+    nav_parser = parser.NavParser(get_nav_for_dir, globber, implicit_index=implicit_index,
+                                  unquote_name=unquote_name)
 
     result = None
     if not nav_data or get_nav_for_dir("."):

--- a/tests/nav/test_unquote.yml
+++ b/tests/nav/test_unquote.yml
@@ -7,7 +7,7 @@ files:
   bar with quote.md:
   baz with space.md:
   foo-without-space.md:
-unquote_name: true
+unquote_links: true
 output:
 - Bar with quote: bar with quote.md
 - Baz with space: baz with space.md

--- a/tests/nav/test_unquote.yml
+++ b/tests/nav/test_unquote.yml
@@ -1,11 +1,14 @@
 files:
   index.md:
   SUMMARY.md: |
+    * [Bar with quote](bar%20with%20quote.md)
     * [Baz with space](baz with space.md)
-    * [Baz-without-space](baz-without-space.md)
+    * [Foo-without-space](foo-without-space.md)
+  bar with quote.md:
   baz with space.md:
-  baz-without-space.md:
+  foo-without-space.md:
 unquote_name: true
 output:
+- Bar with quote: bar with quote.md
 - Baz with space: baz with space.md
-- Baz-without-space: baz-without-space.md
+- Foo-without-space: foo-without-space.md

--- a/tests/nav/test_unquote.yml
+++ b/tests/nav/test_unquote.yml
@@ -1,0 +1,11 @@
+files:
+  index.md:
+  SUMMARY.md: |
+    * [Baz with space](baz with space.md)
+    * [Baz-without-space](baz-without-space.md)
+  baz with space.md:
+  baz-without-space.md:
+unquote_name: true
+output:
+- Baz with space: baz with space.md
+- Baz-without-space: baz-without-space.md

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -28,7 +28,7 @@ def test_nav(tmp_path_factory, golden):
                 files,
                 nav_file_name=golden.get("nav_file_name") or "SUMMARY.md",
                 implicit_index=golden.get("implicit_index"),
-                unquote_name=golden.get("unquote_name"),
+                unquote_links=golden.get("unquote_links"),
             )
     assert output == golden.out.get("output")
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -28,6 +28,7 @@ def test_nav(tmp_path_factory, golden):
                 files,
                 nav_file_name=golden.get("nav_file_name") or "SUMMARY.md",
                 implicit_index=golden.get("implicit_index"),
+                unquote_name=golden.get("unquote_name"),
             )
     assert output == golden.out.get("output")
 


### PR DESCRIPTION
Obsidian.md creates links to other markdown files by using URL quotation so instead `[Link to a file](link to a file.md)` we will see `[Link to a file](link%20to%20a%20file.md)`. If we remove URL quotation manually from a link, then Obsidian.md is not able to support this link and basic functionalities like link jumping and graph display are not working. Since mkdocs can be used as a presentation layer, then a valid place to remove URL quotations is to do it just before parsing markdown files and producing static documentation. Below code introduce a flag `unquote_links` that when set to `true` is responsible for removing a URL quotation from links.